### PR TITLE
Updated the Git clone https address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Watch the full video <a href="https://www.youtube.com/watch?v=GZuAPS48qoA">here<
 
 In the command terminal, run the following commands:
 
-    $ git clone git@github.com:rohan20/flutter-chat-app.git
+    $ git clone https://github.com/rohan20/flutter-chat-app.git
     $ cd flutter-chat-app/
     $ flutter run
 


### PR DESCRIPTION
The command provided in Readme.md for git repo, says 'Permission denied' while cloning it.
Notice the '/' instead of ':'

